### PR TITLE
Fix starter template parsing

### DIFF
--- a/app/utils/selectStarterTemplate.ts
+++ b/app/utils/selectStarterTemplate.ts
@@ -66,8 +66,8 @@ const templates: Template[] = STARTER_TEMPLATES.filter((t) => !t.name.includes('
 const parseSelectedTemplate = (llmOutput: string): { template: string; title: string } | null => {
   try {
     // Extract content between <templateName> tags
-    const templateNameMatch = llmOutput.match(/<templateName>(.*?)<\/templateName>/);
-    const titleMatch = llmOutput.match(/<title>(.*?)<\/title>/);
+  const templateNameMatch = llmOutput.match(/<templateName>([\s\S]*?)<\/templateName>/);
+  const titleMatch = llmOutput.match(/<title>([\s\S]*?)<\/title>/);
 
     if (!templateNameMatch) {
       return null;


### PR DESCRIPTION
## Summary
- fix regex in template selector so multiline values are detected

## Testing
- `npm run lint` *(fails: Cannot find package '@blitz/eslint-plugin')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684be1aec010832dbc6e75ead965f2c8